### PR TITLE
fix: enable debug logging by implementing debug_log (closes #16)

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -2,23 +2,35 @@
 #define DEBUG_H
 
 #include <stdarg.h>
-// #include <stdio.h>
+#include <stdio.h>
 
 #ifdef DEBUG
-// #define debug_log(fmt, ...) debug_log_impl(fmt, ##__VA_ARGS__)
-#define debug_log(fmt, ...) ((void)0)
+
+/*
+ * Print a formatted debug message to standard output.
+ *
+ * The implementation uses a variadic argument list to forward
+ * the arguments to vprintf. A prefix and trailing newline are
+ * added for clarity.
+ */
+static inline void debug_log_impl(const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    printf("[DEBUG]: ");
+    vprintf(format, args);
+    printf("\n");
+    va_end(args);
+}
+
+/* Invoke the implementation when DEBUG is defined. */
+#define debug_log(fmt, ...) debug_log_impl(fmt, ##__VA_ARGS__)
+
 #else
+
+/* No-op when DEBUG is not defined. */
 #define debug_log(fmt, ...) ((void)0)
+
 #endif
 
-// void debug_log_impl(const char *format, ...)
-// {
-//     va_list args;
-//     va_start(args, format);
-//     printf("[DEBUG]: ");
-//     vprintf(format, args);
-//     printf("\n");
-//     va_end(args);
-// }
-
-#endif // !DEBUG_H
+#endif /* !DEBUG_H */


### PR DESCRIPTION
Implement debug_log_impl and macro in debug.h. Include <stdio.h> and variadic implementation. Re-enable debug logging when compiled with DEBUG and leave a no-op otherwise. This resolves issue #16.